### PR TITLE
Fix image margin

### DIFF
--- a/src/main/webapp/css/table-style.css
+++ b/src/main/webapp/css/table-style.css
@@ -24,11 +24,6 @@
         font-size: larger;
     }
     
-	img {
-		margin-left: 10px;
-	}
-
-
     .table-cell.row-heading {
         text-align: left;
     }


### PR DESCRIPTION
This CSS rule applies to all images on your jenkins page, so it produces some unsightly results. I would have suggested a more narrow CSS rule, but I can't find anywhere that this CSS rule is actually being utilized. Happy to modify this to be more narrow if it actually is being used in a place that I missed.

Example:
![Jenkins](https://i.imgur.com/cUv66X1.png)
